### PR TITLE
use key instead of useEffect to reset customizeLanguageDialog

### DIFF
--- a/components/language-chooser/react/language-chooser-react-mui/src/CustomizeLanguageDialog.tsx
+++ b/components/language-chooser/react/language-chooser-react-mui/src/CustomizeLanguageDialog.tsx
@@ -69,50 +69,39 @@ export const CustomizeLanguageDialog: React.FunctionComponent<{
   const EMPTY_COMBOBOX_VALUE = React.useMemo(() => ({ label: "", id: "" }), []);
 
   // Store dialog state. Used to create a tag preview just inside the dialog, before saving anything
+  const initialScript = props.selectedScript?.code
+    ? {
+        label: props.selectedScript.name,
+        id: props.selectedScript.code,
+      }
+    : EMPTY_COMBOBOX_VALUE;
   const [dialogSelectedScript, setDialogSelectedScript] = React.useState<{
     label: string;
     id: string;
-  }>(EMPTY_COMBOBOX_VALUE);
+  }>(initialScript);
+  const initialRegion = props.customizableLanguageDetails.region?.code
+    ? {
+        label: props.customizableLanguageDetails.region.name,
+        id: props.customizableLanguageDetails.region.code,
+      }
+    : EMPTY_COMBOBOX_VALUE;
   const [dialogSelectedRegion, setDialogSelectedRegion] = React.useState<{
     label: string;
     id: string;
-  }>(EMPTY_COMBOBOX_VALUE);
+  }>(initialRegion);
+  const initialDialect = // if the user has not selected any language, not even the unlisted language button, then
+    // there will be no language details and we suggest the search string as a
+    // starting point for the unlisted language name (which is actually stored in the dialect field)
+    props.selectedLanguage
+      ? props.customizableLanguageDetails.dialect || ""
+      : props.searchString;
   const [dialogSelectedDialect, setDialogSelectedDialect] =
-    React.useState<string>("");
+    React.useState<string>(initialDialect);
 
   // name (dialect) and country (region) are required for unlisted language
   const isReadyToSubmit =
     !isUnlistedLanguageDialog ||
     (dialogSelectedDialect !== "" && dialogSelectedRegion.label !== "");
-
-  // To reset the dialog if the user closes and reopens it, since they may have changed the language
-  //or script selection in between
-  React.useEffect(() => {
-    setDialogSelectedScript(
-      props.selectedScript?.code
-        ? {
-            label: props.selectedScript.name,
-            id: props.selectedScript.code,
-          }
-        : EMPTY_COMBOBOX_VALUE
-    );
-    setDialogSelectedRegion(
-      props.customizableLanguageDetails.region?.code
-        ? {
-            label: props.customizableLanguageDetails.region.name,
-            id: props.customizableLanguageDetails.region.code,
-          }
-        : EMPTY_COMBOBOX_VALUE
-    );
-    setDialogSelectedDialect(
-      // if the user has not selected any language, not even the unlisted language button, then
-      // there will be no language details and we suggest the search string as a
-      // starting point for the unlisted language name (which is actually stored in the dialect field)
-      props.selectedLanguage
-        ? props.customizableLanguageDetails.dialect || ""
-        : props.searchString
-    );
-  }, [props, EMPTY_COMBOBOX_VALUE]);
 
   const theme = useTheme();
 

--- a/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
+++ b/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
@@ -464,6 +464,7 @@ export const LanguageChooser: React.FunctionComponent<ILanguageChooserProps> = (
         </div>
       </div>
       <CustomizeLanguageDialog
+        key={lp.selectedLanguage?.iso639_3 + "_" + lp.selectedScript?.code} // This is to force a re-render when the user has changed language or script selection and then reopens dialog
         open={customizeLanguageDialogOpen}
         selectedLanguage={lp.selectedLanguage}
         selectedScript={lp.selectedScript}


### PR DESCRIPTION
Just a small refactor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/EthnoLib/47)
<!-- Reviewable:end -->
