### PR TITLE
fix: BL-14361 hide tooltip when reference element scrolls out of view

### DIFF
--- a/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
+++ b/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
@@ -448,6 +448,14 @@ export const LanguageChooser: React.FunctionComponent<ILanguageChooserProps> = (
                           title="Select a script"
                           placement="right"
                           open={!lp.selectedScript}
+                          css={css`
+                            // hide popper when reference element (the script cards) is scrolled out of view
+                            // https://popper.js.org/docs/v2/modifiers/hide/
+                            &[data-popper-reference-hidden] {
+                              visibility: hidden;
+                              pointer-events: none;
+                            }
+                          `}
                         >
                           <List
                             css={css`


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/EthnoLib/71)
<!-- Reviewable:end -->
