### PR TITLE
fix: BL-14361: hide tooltip when customization dialog is open on top

### DIFF
--- a/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
+++ b/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
@@ -455,6 +455,14 @@ export const LanguageChooser: React.FunctionComponent<ILanguageChooserProps> = (
                               visibility: hidden;
                               pointer-events: none;
                             }
+
+                            // Also hide the popper if the customization dialog is open
+                            ${customizeLanguageDialogOpen
+                              ? `
+                              visibility: hidden;
+                              pointer-events: none;
+                            `
+                              : ""}
                           `}
                         >
                           <List


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/EthnoLib/72)
<!-- Reviewable:end -->
