### PR TITLE
fix: BL-14824 select microlanguage not macrolanguage

### DIFF
--- a/components/language-chooser/common/find-language/searchForLanguage.spec.ts
+++ b/components/language-chooser/common/find-language/searchForLanguage.spec.ts
@@ -345,6 +345,21 @@ describe("getLanguageBySubtag", () => {
   it("should find languages by valid languageSubtag field", () => {
     expect(getLanguageBySubtag("aaa")?.exonym).toEqual("Ghotuo");
     expect(getLanguageBySubtag("ab")?.exonym).toEqual("Abkhaz");
+    expect(getLanguageBySubtag("uz")?.exonym).toEqual("Uzbek");
+    expect(getLanguageBySubtag("mg")?.iso639_3_code).toEqual("plt");
+    expect(getLanguageBySubtag("zh")?.exonym).toEqual("Chinese");
+    expect(getLanguageBySubtag("za")?.exonym).toEqual("Zhuang");
+    expect(getLanguageBySubtag("ak")?.iso639_3_code).toEqual("twi");
+    expect(getLanguageBySubtag("bnc")?.iso639_3_code).toEqual("lbk");
+    expect(getLanguageBySubtag("no")?.exonym).toEqual("Norwegian");
+    expect(getLanguageBySubtag("sh")?.iso639_3_code).toEqual("hbs");
+    expect(getLanguageBySubtag("sa")?.exonym).toEqual("Sanskrit");
+    expect(getLanguageBySubtag("zap")?.exonym).toEqual("Zapotec");
+    expect(getLanguageBySubtag("ik")?.iso639_3_code).toEqual("esk");
+    expect(getLanguageBySubtag("id")?.exonym).toEqual("Indonesian");
+    expect(getLanguageBySubtag("ja")?.exonym).toEqual("Japanese");
+    expect(getLanguageBySubtag("yi")?.autonym).toEqual("ייִדיש");
+    expect(getLanguageBySubtag("luy")?.iso639_3_code).toEqual("bxk");
   });
   it("should use searchResultModifier if provided", () => {
     const foobar = "foobar";

--- a/components/language-chooser/react/common/language-chooser-react-hook/useLanguageChooser.ts
+++ b/components/language-chooser/react/common/language-chooser-react-hook/useLanguageChooser.ts
@@ -197,9 +197,11 @@ export const useLanguageChooser = (
 
   function selectScript(script: IScript) {
     setSelectedScript(script);
+    clearCustomizableLanguageDetails();
   }
   function clearScriptSelection() {
     setSelectedScript(undefined);
+    clearCustomizableLanguageDetails();
   }
 
   function onSearchStringChange(searchString: string) {

--- a/components/language-chooser/react/language-chooser-react-mui/src/demos/DialogDemo.tsx
+++ b/components/language-chooser/react/language-chooser-react-mui/src/demos/DialogDemo.tsx
@@ -33,11 +33,12 @@ export const DialogDemo: React.FunctionComponent<{
   initialLanguageTag,
   demoRightPanelComponent,
   primaryColor,
+  initialSearchString: demoInitialSearchString,
   ...languageChooserDialogProps
 }) => {
   // To demonstrate the ability to reopen to a desired state
   const initialSelection: IOrthography | undefined =
-    parseLangtagFromLangChooser(initialLanguageTag || "");
+    parseLangtagFromLangChooser(initialLanguageTag || "", defaultSearchResultModifier);
   if (initialSelection?.language) {
     initialSelection.customDetails = {
       ...(initialSelection.customDetails || []),
@@ -48,6 +49,9 @@ export const DialogDemo: React.FunctionComponent<{
   }
 
   const [open, setOpen] = React.useState(true);
+  if (initialSelection && demoInitialSearchString) {
+    console.warn("When both initialLanguageTag and initialSearchString are entered, initialSearchString will be ignored.")
+  }
   const [selectedValue, setSelectedValue] = React.useState(
     initialSelection || ({} as IOrthography)
   );
@@ -136,10 +140,10 @@ export const DialogDemo: React.FunctionComponent<{
           </div>
 
           <LanguageChooserDialog
+            {...languageChooserDialogProps}
             open={open}
             uiLanguage={uiLanguage}
             searchResultModifier={defaultSearchResultModifier}
-            initialSearchString={selectedValue?.language?.languageSubtag}
             initialSelectionLanguageTag={languageTag}
             initialCustomDisplayName={
               selectedValue?.customDetails?.customDisplayName
@@ -149,7 +153,7 @@ export const DialogDemo: React.FunctionComponent<{
             rightPanelComponent={
               demoRightPanelComponent ? <DummyRightPanelComponent /> : undefined
             }
-            {...languageChooserDialogProps}
+            initialSearchString={selectedValue?.language?.languageSubtag || demoInitialSearchString}
           />
         </div>
       </div>


### PR DESCRIPTION
If a macrolanguage is chosen, next time opening the language chooser, the representative microlanguage will be the initially selected language.