### PR TITLE
fix: BL-14824 Make search box start empty

### DIFF
--- a/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
+++ b/components/language-chooser/react/language-chooser-react-mui/src/LanguageChooser.tsx
@@ -141,7 +141,8 @@ export const LanguageChooserInner: React.FunctionComponent<
 
   useEffect(() => {
     if (searchInputRef) {
-      searchInputRef.value = props.initialSearchString || "";
+      // (BL-14824) On reopening, leave search box blank, but search will still show results
+      searchInputRef.value = "";
       searchInputRef.focus();
     }
     if (props.initialSearchString) {


### PR DESCRIPTION
On reopening, the search box will start empty, but the search results will still show